### PR TITLE
Notify api option added

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,15 +58,15 @@ Executor comes with the following defaults:
         }
 
     },
-     default_mappings = true, -- use default mapping
+    default_mappings = true, -- use default mapping
+    notify = true -- Use the notify api
     always_exit = true, -- always exit terminal no matter status of previous
-    command
-
-     dependency_commands = {
-         -- the command make requires the presents of a makefile in cwd, if
-         -- makefile is not found, try next command in table
-         make = "makefile"
-     }
+	insert_on_enter = false, -- enter insert mode on entering a terminal
+    dependency_commands = {
+        -- the command make requires the presents of a makefile in cwd, if
+        -- makefile is not found, try next command in table
+        make = "makefile"
+    }
 }
 ```
 

--- a/lua/executor.lua
+++ b/lua/executor.lua
@@ -50,7 +50,9 @@ function M.executor()
 
 		-- if not external terminal, run command as a vim command
 		if commandTbl.extern == false then
-			vim.notify(command)
+			if settings.notify == true then
+				vim.notify(command)
+			end
 			vim.cmd(command)
 			-- stop after command has been excuted
 			return

--- a/lua/utils.lua
+++ b/lua/utils.lua
@@ -3,6 +3,7 @@ local M = {}
 ---@class ExecutorOptions
 ---@field commands table commands for each filetype
 ---@field default_mappings boolean weather to define default mappings
+---@field notify boolean weather not to use the notify api
 ---@field always_exit boolean always append `|| exit` to command
 ---@field insert_on_enter boolean enter insert mode when spawning a new terminal
 ---@field dependency_commands table commands that require a dependency file
@@ -31,6 +32,7 @@ M.default_opts = {
 		},
 	},
 	default_mappings = true,
+	notify = false,
 	always_exit = true, -- always exit terminal no matter status of previous command
 	insert_on_enter = false, -- enter insert mode on entering a terminal
 	dependency_commands = {


### PR DESCRIPTION
# Why ?
I was annoyed by the notifications of the runs. Those notifications could sometimes become really long if the command behind was a little elaborated.

# The Changes
Added an option to deactivate the use of the notify API.

- notify boolean in options
- documentation update